### PR TITLE
Add error handling in useQueryParam

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,10 @@
 module.exports = {
-  extends: '@seasonedsoftware/eslint-config',
-  parser: 'babel-eslint',
+  parser: "babel-eslint",
+  ignorePatterns: ["./example/**/*.js"],
   rules: {
-    'sort-keys': 0,
-    'no-use-before-define': 0,
-    'no-unused-expressions': 0,
-    'import/extensions': 0,
-  },
-}
+    "sort-keys": 0,
+    "no-use-before-define": 0,
+    "no-unused-expressions": 0,
+    "import/extensions": 0
+  }
+};

--- a/src/hooks/useQueryParam.tsx
+++ b/src/hooks/useQueryParam.tsx
@@ -1,6 +1,9 @@
 import isArray from 'lodash/isArray'
+import isNull from 'lodash/isNull'
+import isUndefined from 'lodash/isUndefined'
 
 export function useQueryParam(param: string | Array<string>) {
+  if (isNull(param) || isUndefined(param)) throw new Error('Missing param for useQueryParam')
   const params = new URLSearchParams(window.location.search)
   return isArray(param) ? param.reduce((pv, current) => ({...pv, [current]: params.get(current)}), {}) : params.get(param)
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1606048/139318461-187617ac-9dec-470d-88f1-b3fca524576f.png)
This case was the motivation to create this PR!
If you don't pass any parameter for useQueryParam, the hooks are returning `null`
The idea of this PR is to show are a more clear error message

Also this PR removes the Seasoned eslint config, once the project don't build with this eslint config